### PR TITLE
fetch: rework to use data sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,21 @@ on:
 jobs:
   lint_python:
     name: Lint Python Code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Linters
         run: make venv
       - name: Lint
         run: make lint
   push_to_pypi:
     name: Build (and publish, if applicable)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: lint_python
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Export Repo URL

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logs/
 pdks/
 /result
 requirements_tmp.txt
+download/

--- a/ciel/__main__.py
+++ b/ciel/__main__.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The American University in Cairo
+#
+# Adapted from the Volare project
+#
 # Copyright 2022-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +45,7 @@ from .build import (
     build_cmd,
     push_cmd,
 )
+from .source import DataSource
 
 
 @click.command("output")
@@ -139,8 +144,7 @@ def list_remote_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
     try:
-        all_versions = Version._from_github()
-        pdk_versions = all_versions.get(pdk) or []
+        pdk_versions = DataSource.default.get_available_versions(pdk)
 
         if sys.stdout.isatty():
             console = Console()
@@ -148,6 +152,13 @@ def list_remote_cmd(pdk_root, pdk):
         else:
             for version in pdk_versions:
                 print(version.name)
+    except ValueError as e:
+        if sys.stdout.isatty():
+            console = Console()
+            console.print(f"[red]{e}")
+        else:
+            print(f"{e}", file=sys.stderr)
+        sys.exit(-1)
     except httpx.HTTPStatusError as e:
         if sys.stdout.isatty():
             console = Console()

--- a/ciel/__main__.py
+++ b/ciel/__main__.py
@@ -29,11 +29,7 @@ from .common import (
     resolve_version,
 )
 from .click_common import (
-    opt,
-    opt_build,
-    opt_push,
     opt_pdk_root,
-    opt_token,
 )
 from .manage import (
     print_installed_list,
@@ -45,7 +41,8 @@ from .build import (
     build_cmd,
     push_cmd,
 )
-from .source import DataSource
+from .github import opt_github_token
+from .source import opt_data_source
 
 
 @click.command("output")
@@ -118,9 +115,10 @@ def rm_cmd(pdk_root, pdk, version):
 
 
 @click.command("ls")
-@opt_token
+@opt_data_source
+@opt_github_token
 @opt_pdk_root
-def list_cmd(pdk_root, pdk):
+def list_cmd(data_source, pdk_root, pdk):
     """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
 
     pdk_versions = Version.get_all_installed(pdk_root, pdk)
@@ -130,6 +128,7 @@ def list_cmd(pdk_root, pdk):
         print_installed_list(
             pdk_root,
             pdk,
+            data_source=data_source,
             console=console,
             installed_list=pdk_versions,
         )
@@ -138,13 +137,14 @@ def list_cmd(pdk_root, pdk):
 
 
 @click.command("ls-remote")
-@opt_token
+@opt_github_token
+@opt_data_source
 @opt_pdk_root
-def list_remote_cmd(pdk_root, pdk):
+def list_remote_cmd(data_source, pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
     try:
-        pdk_versions = DataSource.default.get_available_versions(pdk)
+        pdk_versions = data_source.get_available_versions(pdk)
 
         if sys.stdout.isatty():
             console = Console()
@@ -195,7 +195,8 @@ def path_cmd(pdk_root, pdk, version):
 
 
 @click.command("enable")
-@opt_token
+@opt_data_source
+@opt_github_token
 @opt_pdk_root
 @click.option(
     "-f",
@@ -213,6 +214,7 @@ def path_cmd(pdk_root, pdk, version):
 )
 @click.argument("version", required=False)
 def enable_cmd(
+    data_source,
     pdk_root,
     pdk,
     tool_metadata_file_path,
@@ -245,6 +247,7 @@ def enable_cmd(
             version,
             include_libraries=include_libraries,
             output=console,
+            data_source=data_source,
         )
     except Exception as e:
         console.print(f"[red]{e}")
@@ -252,7 +255,8 @@ def enable_cmd(
 
 
 @click.command("fetch")
-@opt_token
+@opt_data_source
+@opt_github_token
 @opt_pdk_root
 @click.option(
     "-f",
@@ -270,6 +274,7 @@ def enable_cmd(
 )
 @click.argument("version", required=False)
 def fetch_cmd(
+    data_source,
     pdk_root,
     pdk,
     tool_metadata_file_path,
@@ -298,6 +303,7 @@ def fetch_cmd(
 
     try:
         version = fetch(
+            data_source=data_source,
             pdk_root=pdk_root,
             pdk=pdk,
             version=version,
@@ -306,79 +312,6 @@ def fetch_cmd(
         )
         print(version.get_dir(pdk_root), end="")
 
-    except Exception as e:
-        console.print(f"[red]{e}")
-        exit(-1)
-
-
-@click.command("enable_or_build", hidden=True)
-@opt_token
-@opt_pdk_root
-@opt_push
-@opt_build
-@opt("--also-push/--dont-push", default=False, help="Also push.")
-@click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.argument("version")
-def enable_or_build_cmd(
-    include_libraries,
-    jobs,
-    pdk_root,
-    pdk,
-    owner,
-    repository,
-    pre,
-    clear_build_artifacts,
-    tool_metadata_file_path,
-    also_push,
-    version,
-    use_repo_at,
-    push_libraries,
-):
-    """
-    Attempts to activate a given PDK version. If the version is not found locally or remotely,
-    it will instead attempt to build said version.
-
-    Parameters: <version>
-    """
-    if include_libraries == ():
-        include_libraries = None
-    if push_libraries == ():
-        push_libraries = include_libraries
-
-    console = Console()
-    try:
-        version = resolve_version(version, tool_metadata_file_path)
-    except Exception as e:
-        console.print(f"Could not determine open_pdks version: {e}")
-        exit(-1)
-    try:
-        enable(
-            pdk_root=pdk_root,
-            pdk=pdk,
-            version=version,
-            build_if_not_found=True,
-            also_push=also_push,
-            build_kwargs={
-                "include_libraries": include_libraries,
-                "jobs": jobs,
-                "clear_build_artifacts": clear_build_artifacts,
-                "use_repo_at": use_repo_at,
-            },
-            push_kwargs={
-                "owner": owner,
-                "repository": repository,
-                "pre": pre,
-                "push_libraries": push_libraries,
-            },
-            include_libraries=include_libraries,
-            output=console,
-        )
     except Exception as e:
         console.print(f"[red]{e}")
         exit(-1)
@@ -415,7 +348,6 @@ cli.add_command(list_cmd)
 cli.add_command(list_remote_cmd)
 cli.add_command(enable_cmd)
 cli.add_command(fetch_cmd)
-cli.add_command(enable_or_build_cmd)
 
 try:
     import ssl  # noqa: F401

--- a/ciel/build/__init__.py
+++ b/ciel/build/__init__.py
@@ -32,6 +32,7 @@ from rich.progress import Progress
 from ..github import (
     GitHubSession,
     get_commit_date,
+    opt_github_token,
 )
 from ..common import (
     Version,
@@ -43,7 +44,6 @@ from ..click_common import (
     opt_push,
     opt_build,
     opt_pdk_root,
-    opt_token,
 )
 from ..families import Family
 
@@ -82,7 +82,7 @@ def build(
 
 
 @click.command("build")
-@opt_token
+@opt_github_token
 @opt_pdk_root
 @opt_build
 @click.option(
@@ -232,7 +232,7 @@ def push(
 
 
 @click.command("push", hidden=True)
-@opt_token
+@opt_github_token
 @opt_pdk_root
 @opt_push
 @click.argument("version")

--- a/ciel/build/__init__.py
+++ b/ciel/build/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The American University in Cairo
+#
+# Adapted from the Volare project
+#
 # Copyright 2022-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +32,6 @@ from rich.progress import Progress
 from ..github import (
     GitHubSession,
     get_commit_date,
-    volare_repo,
 )
 from ..common import (
     Version,
@@ -135,16 +138,14 @@ def push(
     pdk,
     version,
     *,
-    owner=volare_repo.owner,
-    repository=volare_repo.name,
+    owner,
+    repository,
     pre=False,
     push_libraries=None,
-    session: Optional[GitHubSession] = None,
 ):
     family = Family.by_name[pdk]
 
-    if session is None:
-        session = GitHubSession()
+    session = GitHubSession()
     if session.github_token is None:
         raise TypeError("No GitHub token was provided.")
 

--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -17,12 +17,11 @@
 # limitations under the License.
 import os
 from functools import partial
-from typing import Callable, Optional
+from typing import Callable
 
 import click
 
 from .common import VOLARE_RESOLVED_HOME
-from .github import GitHubSession
 
 opt = partial(click.option, show_default=True)
 
@@ -95,27 +94,5 @@ def opt_push(function: Callable):
         multiple=True,
         default=None,
         help="Push only libraries in this list. You can use -L multiple times to include multiple libraries. Pass 'None' to push all libraries built.",
-    )(function)
-    return function
-
-
-def set_token_cb(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: Optional[str],
-):
-    GitHubSession.Token.override = value
-
-
-def opt_token(function: Callable) -> Callable:
-    function = opt(
-        "-t",
-        "--token",
-        "session",
-        default=None,
-        required=False,
-        expose_value=False,
-        help="Replace the GitHub token used for GitHub requests, which is by default the value of the environment variable GITHUB_TOKEN or None.",
-        callback=set_token_cb,
     )(function)
     return function

--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The American University in Cairo
+#
+# Adapted from the Volare project
+#
 # Copyright 2022-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +22,7 @@ from typing import Callable, Optional
 import click
 
 from .common import VOLARE_RESOLVED_HOME
-from .github import volare_repo, GitHubSession
+from .github import GitHubSession
 
 opt = partial(click.option, show_default=True)
 
@@ -77,12 +81,10 @@ def opt_build(function: Callable):
 
 
 def opt_push(function: Callable):
-    function = opt("-o", "--owner", default=volare_repo.owner, help="Repository Owner")(
+    function = opt("-o", "--owner", default="efabless", help="Repository Owner")(
         function
     )
-    function = opt("-r", "--repository", default=volare_repo.name, help="Repository")(
-        function
-    )
+    function = opt("-r", "--repository", default="volare", help="Repository")(function)
     function = opt(
         "--pre/--prod", default=False, help="Push as pre-release or production"
     )(function)

--- a/ciel/common.py
+++ b/ciel/common.py
@@ -16,14 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import re
 import shutil
 import pathlib
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Iterable, Optional, List, Dict, Tuple
+from typing import Optional, List
 
-from . import github
 from .families import Family
 
 # -- Assorted Helper Functions

--- a/ciel/github.py
+++ b/ciel/github.py
@@ -16,11 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import subprocess
 import sys
+import click
+import subprocess
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, Callable
 
 import httpx
 import ssl
@@ -163,3 +164,25 @@ def get_commit_date(
     date = response["commit"]["author"]["date"]
     commit_date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return commit_date
+
+
+def set_token_cb(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: Optional[str],
+):
+    GitHubSession.Token.override = value
+
+
+def opt_github_token(function: Callable) -> Callable:
+    function = click.option(
+        "-t",
+        "--github-token",
+        default=None,
+        required=False,
+        expose_value=False,
+        show_default=True,
+        help="Replace the token used for GitHub requests, which is by default the value of the environment variable GITHUB_TOKEN or None.",
+        callback=set_token_cb,
+    )(function)
+    return function

--- a/ciel/github.py
+++ b/ciel/github.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Any, ClassVar, List, Mapping, Optional
+from typing import Any, ClassVar, Optional
 
 import httpx
 import ssl

--- a/ciel/manage.py
+++ b/ciel/manage.py
@@ -49,6 +49,7 @@ def print_installed_list(
     pdk_root: str,
     pdk: str,
     *,
+    data_source: DataSource,
     console: Console,
     installed_list: List[Version],
 ):
@@ -59,7 +60,7 @@ def print_installed_list(
     versions = installed_list
 
     try:
-        remote_versions = DataSource.default.get_available_versions(pdk)
+        remote_versions = data_source.get_available_versions(pdk)
         remote_version_dict = {rv.name: rv for rv in remote_versions}
         for installed in installed_list:
             remote_version = remote_version_dict.get(installed.name)
@@ -120,6 +121,7 @@ def fetch(
     pdk: str,
     version: str,
     *,
+    data_source: DataSource,
     build_if_not_found=False,
     also_push=False,
     build_kwargs: dict = {},
@@ -176,9 +178,7 @@ def fetch(
 
         tarball_paths = []
         try:
-            client, assets = DataSource.default.get_downloads_for_version(
-                version_object
-            )
+            client, assets = data_source.get_downloads_for_version(version_object)
             assets_filtered = []
             for asset in assets:
                 if asset.content == "common" and common_missing:
@@ -286,6 +286,7 @@ def enable(
     pdk: str,
     version: str,
     *,
+    data_source: DataSource,
     build_if_not_found: bool = False,
     also_push: bool = False,
     build_kwargs: dict = {},
@@ -313,6 +314,7 @@ def enable(
         pdk_root,
         pdk,
         version,
+        data_source=data_source,
         build_if_not_found=build_if_not_found,
         also_push=also_push,
         build_kwargs=build_kwargs,

--- a/ciel/manage.py
+++ b/ciel/manage.py
@@ -31,7 +31,6 @@ import zstandard as zstd
 from rich.console import Console
 
 from .build.git_multi_clone import mkdirp
-from .github import GitHubSession
 from .common import (
     Version,
     get_versions_dir,

--- a/ciel/source.py
+++ b/ciel/source.py
@@ -1,0 +1,149 @@
+# Copyright 2025 The American University in Cairo
+#
+# Modified from the Volare project
+#
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import re
+from dataclasses import dataclass
+import sys
+from typing import Dict, ClassVar, List, Tuple, Type
+
+import httpx
+
+from .github import GitHubSession, RepoInfo
+from .common import Version, date_from_iso8601
+
+
+@dataclass
+class Asset:
+    content: str
+    filename: str
+    url: str
+
+
+class DataSource(object):
+    factory: ClassVar[Dict[str, Type["DataSource"]]] = {}
+    default: ClassVar["DataSource"]
+
+    def get_available_versions(self, pdk: str) -> List[Version]:
+        raise NotImplementedError()
+
+    def get_downloads_for_version(
+        self, version: Version
+    ) -> Tuple[httpx.Client, List[Asset]]:
+        raise NotImplementedError()
+
+
+class GitHubReleasesDataSource(object):
+    def __init__(self, repo_id: str):
+        self.session = GitHubSession()
+        self.repo = RepoInfo.from_id(repo_id)
+
+    def get_available_versions(self, pdk: str) -> List[Version]:
+        page = 1
+        last = self.session.api(
+            self.repo,
+            "/releases",
+            "get",
+            params={"page": 1, "per_page": 100},
+        )
+        releases = last
+        while len(last) == 100:
+            page += 1
+            last = self.session.api(
+                self.repo,
+                "/releases",
+                "get",
+                params={"page": 1, "per_page": 100},
+            )
+            releases += last
+
+        versions = []
+        commit_rx = re.compile(r"released on ([\d\-\:TZ]+)")
+        for release in releases:
+            if release["draft"]:
+                continue
+
+            family, hash = release["tag_name"].rsplit("-", maxsplit=1)
+
+            if pdk != family:
+                continue
+
+            upload_date = date_from_iso8601(release["published_at"])
+            commit_date = None
+
+            commit_date_match = commit_rx.search(release["body"])
+            if commit_date_match is not None:
+                commit_date = date_from_iso8601(commit_date_match[1])
+
+            remote_version = Version(
+                name=hash,
+                pdk=family,
+                commit_date=commit_date,
+                upload_date=upload_date,
+                prerelease=release["prerelease"],
+            )
+            versions.append(remote_version)
+
+        versions.sort(reverse=True)
+        if len(versions) == 0:
+            raise ValueError(
+                f"No versions found for '{pdk}' on github.com/{self.repo.id}"
+            )
+        return versions
+
+    def get_downloads_for_version(
+        self, version: Version
+    ) -> Tuple[httpx.Client, List[Asset]]:
+        release = self.session.api(
+            self.repo,
+            f"/releases/tags/{version.pdk}-{version.name}",
+            "get",
+        )
+
+        assets = release["assets"]
+        zst_files = []
+        for asset in assets:
+            if asset["name"].endswith(".tar.zst"):
+                content = asset["name"][:-8]
+                zst_files.append(
+                    Asset(content, asset["name"], asset["browser_download_url"])
+                )
+        return zst_files
+
+
+DataSource.factory["github-releases"] = GitHubReleasesDataSource
+
+
+def __set_data_source_default():
+    source_id = os.getenv("CIEL_DATA_SOURCE", "github-releases:efabless/volare")
+    elements = source_id.split(":", maxsplit=1)
+    if len(elements) != 2:
+        print(
+            f"[CRITICAL] CIEL_DATA_SOURCE must be in the format '{{class_id}}:{{argument}}'."
+        )
+        sys.exit(-1)
+    cls_id, target = elements
+    cls = DataSource.factory.get(cls_id)
+    if cls is None:
+        print(
+            f"[CRITICAL] CIEL_DATA_SOURCE defines unknown data source class '{cls_id}'"
+        )
+        sys.exit(-1)
+    DataSource.default = cls(target)
+
+
+__set_data_source_default()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "0.21.0dev1"
+version = "1.0.0dev0"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
 name = "ciel"
-version = "1.0.0dev0"
+version = "1.0.0"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
-authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
+authors = [
+    "Mohamed Gaber <me@donn.website>",
+    "Efabless Corporation"
+]
 readme = "Readme.md"
 license = "Apache-2.0"
 repository = "https://github.com/fossi-foundation/ciel"


### PR DESCRIPTION
Introduces the concept of a DataSource to Ciel, an abstraction of remote data repositories. There are two concrete implementations thereof:

* GitHubReleasesDataSource: Which uses GitHub Releases, effectively behaving identically to Volare.
* StaticWebDataSource: Which uses a static webpage to fetch manifest files that replace the API calls in questions.

Users can provide the data source over the command-line using `--data-source {class}:{argument}`, where class can be `github-releases` or `static-web` respectively. When the data source is `github-releases`, the argument is in the format '{owner}/{repo}', and when the data source is a static website, the argument is a URL to the base directory where the manifest files are located. The manifest files are free to point to any file on the internet for download information.

The default data source is `static-web:https://fossi-foundation.github.io/ciel-releases`. To act identically to Volare, the data source can be `github-releases:efabless/volare`.