### PR TITLE
feat!: skyfall

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ ciel --version
 # About the builds
 In its current inception, ciel supports builds of **sky130** and **gf180mcu** PDKs using [Open_PDKs](https://github.com/efabless/open_pdks), including the following libraries:
 
-|sky130|gf180mcu|ihp_sg13g2|
+|sky130|gf180mcu|ihp-sg13g2|
 |-|-|-|
 |sky130_fd_io|gf180mcu_fd_io|sg13g2_io|
 |sky130_fd_pr|gf180mcu_fd_pr|sg13g2_pr|
@@ -60,16 +60,16 @@ In its current inception, ciel supports builds of **sky130** and **gf180mcu** PD
 |sky130_fd_sc_hs|-|-|
 |sky130_sram_macros|gf180mcu_fd_ip_sram|sg13g2_sram|
 
-Builds for sky130 and gf180mcu are identified by their [**open_pdks**](https://github.com/rtimothyedwards/open_pdks) commit hashes. Builds for ihp_sg13g2 are identified by their [**IHP-Open-PDK**](https://github.com/ihp-gmbh/ihp-open-pdk) commit hashes.
+Builds for sky130 and gf180mcu are identified by their [**open_pdks**](https://github.com/rtimothyedwards/open_pdks) commit hashes. Builds for ihp-sg13g2 are identified by their [**IHP-Open-PDK**](https://github.com/ihp-gmbh/ihp-open-pdk) commit hashes.
 
 # Usage
 Ciel requires a so-called **PDK Root**. This PDK root can be anywhere on your computer, but by default it's the folder `~/.ciel` in your home directory. If you have the variable `PDK_ROOT` set, ciel will use that instead. You can also manually override both values by supplying the `--pdk-root` commandline argument.
 
 ## Listing All Available PDKs
-To list all available pre-built PDKs hosted in this repository, you can just invoke `ciel ls-remote --pdk <PDK>`. If you omit the `--pdk` argument, `sky130` will be used as a default.
+To list all available pre-built PDK families hosted in this repository, you can just invoke `ciel ls-remote --pdk-family <pdk-family>`.
 
 ```sh
-$ ciel ls-remote --pdk sky130
+$ ciel ls-remote --pdk-family sky130
 Pre-built sky130 PDK versions
 ├── 44a43c23c81b45b8e774ae7a84899a5a778b6b0b (2022.08.16) (enabled)
 ├── e8294524e5f67c533c5d0c3afa0bcc5b2a5fa066 (2022.07.29) (installed)
@@ -79,7 +79,7 @@ Pre-built sky130 PDK versions
 ├── 8fe7f760ece2bb49b1c310e60243f0558977dae5 (2022.04.06)
 └── 7519dfb04400f224f140749cda44ee7de6f5e095 (2022.02.10)
 
-$ ciel ls-remote --pdk gf180mcu
+$ ciel ls-remote --pdk-family gf180mcu
 Pre-built gf180mcu PDK versions
 └── 120b0bd69c745825a0b8b76f364043a1cd08bb6a (2022.09.22)
 ```
@@ -87,10 +87,10 @@ Pre-built gf180mcu PDK versions
 It includes a hash of the commit of the relevant repo used for that particular build, the date that this commit was created, and whether you already installed this PDK and/or if it is the currently enabled PDK.
 
 ## Listing Installed PDKs
-Typing `ciel ls --pdk <pdk>` in the terminal shows you your PDK Root and the PDKs you currently have installed. Again, if you omit the `--pdk` argument, `sky130` will be used as a default.
+Typing `ciel ls --pdk-family <pdk-family>` in the terminal shows you your PDK Root and the PDKs you currently have installed.
 
 ```sh
-$ ciel ls --pdk sky130
+$ ciel ls --pdk-family sky130
 /home/test/ciel/sky130/versions
 ├── 44a43c23c81b45b8e774ae7a84899a5a778b6b0b (2022.08.16) (enabled)
 ├── e8294524e5f67c533c5d0c3afa0bcc5b2a5fa066 (2022.07.29)
@@ -101,12 +101,12 @@ $ ciel ls --pdk sky130
 
 
 ## Downloading and Enabling PDKs
-You can enable a particular sky130 PDK by invoking `ciel enable --pdk <pdk> <open_pdks commit hash>`. This will automatically download that particular version of the PDK, if found, and set it as your currently used PDK.
+You can enable a particular sky130 PDK by invoking `ciel enable --pdk-family <pdk-family> <open_pdks commit hash>`. This will automatically download that particular version of the PDK, if found, and set it as your currently used PDK.
 
-For example, to activate a build of sky130 using open_pdks `7519dfb04400f224f140749cda44ee7de6f5e095`, you invoke `ciel enable --pdk sky130 7519dfb04400f224f140749cda44ee7de6f5e095`, as shown below:
+For example, to activate a build of sky130 using open_pdks `7519dfb04400f224f140749cda44ee7de6f5e095`, you invoke `ciel enable --pdk-family sky130 7519dfb04400f224f140749cda44ee7de6f5e095`, as shown below:
 
 ```sh
-$ ciel enable --pdk sky130 7519dfb04400f224f140749cda44ee7de6f5e095
+$ ciel enable --pdk-family sky130 7519dfb04400f224f140749cda44ee7de6f5e095
 Downloading pre-built tarball for 7519dfb04400f224f140749cda44ee7de6f5e095… ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 Unpacking…                                                                  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 PDK version 7519dfb04400f224f140749cda44ee7de6f5e095 enabled.

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ In its current inception, ciel supports builds of **sky130** and **gf180mcu** PD
 |-|-|-|
 |sky130_fd_io|gf180mcu_fd_io|sg13g2_io|
 |sky130_fd_pr|gf180mcu_fd_pr|sg13g2_pr|
-|sky130_fd_pr_reram$|gf180mcu_fd_pr|sg13g2_pr|
+|sky130_fd_pr_reram|gf180mcu_fd_pr|sg13g2_pr|
 |sky130_fd_sc_hd|gf180mcu_fd_sc_mcu7t5v0|sg13g2_stdcell|
 |sky130_ml_xx_hd|gf180mcu_fd_sc_mcu9t5v0|-|
 |sky130_fd_sc_hvl|gf180mcu_osu_sc_gp9t3v3|-|

--- a/ciel/__main__.py
+++ b/ciel/__main__.py
@@ -27,7 +27,6 @@ from .common import (
     Version,
     get_ciel_home,
     resolve_version,
-    print_available_pdk_families,
 )
 from .click_common import (
     opt_pdk_root,
@@ -55,9 +54,6 @@ def output_cmd(pdk_root, pdk_family):
     unembellished, or, if no current version is enabled, an empty output with an
     exit code of 1.
     """
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     version = Version.get_current(pdk_root, pdk_family)
     if sys.stdout.isatty():
@@ -88,9 +84,6 @@ def output_cmd(pdk_root, pdk_family):
 )
 def prune_cmd(pdk_root, pdk_family):
     """Removes all PDKs other than, if it exists, the one currently in use."""
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     pdk_versions = Version.get_all_installed(pdk_root, pdk_family)
     for version in pdk_versions:
@@ -115,9 +108,6 @@ def prune_cmd(pdk_root, pdk_family):
 @click.argument("version", required=False)
 def rm_cmd(pdk_root, pdk_family, version):
     """Removes the PDK version specified."""
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     version_object = Version(version, pdk_family)
     try:
@@ -134,9 +124,6 @@ def rm_cmd(pdk_root, pdk_family, version):
 @opt_pdk_root
 def list_cmd(data_source, pdk_root, pdk_family):
     """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     pdk_versions = Version.get_all_installed(pdk_root, pdk_family)
 
@@ -159,10 +146,6 @@ def list_cmd(data_source, pdk_root, pdk_family):
 @opt_pdk_root
 def list_remote_cmd(data_source, pdk_root, pdk_family):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
-
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     try:
         pdk_versions = data_source.get_available_versions(pdk_family)
@@ -209,10 +192,6 @@ def path_cmd(pdk_root, pdk_family, version):
     version instead.
     """
     if version is not None:
-        if pdk_family is None:
-            print_available_pdk_families()
-            exit(-1)
-
         version = Version(version, pdk_family)
         print(version.get_dir(pdk_root), end="")
     else:
@@ -255,9 +234,6 @@ def enable_cmd(
     tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
     the appropriate version will be enabled automatically.
     """
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     if include_libraries == ():
         include_libraries = None
@@ -320,9 +296,6 @@ def fetch_cmd(
     tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
     the appropriate version will be enabled automatically.
     """
-    if pdk_family is None:
-        print_available_pdk_families()
-        exit(-1)
 
     if include_libraries == ():
         include_libraries = None

--- a/ciel/build/ihp_sg13g2.py
+++ b/ciel/build/ihp_sg13g2.py
@@ -83,9 +83,9 @@ def build_ihp(build_directory, ihp_path):
 def install_ihp(build_directory, pdk_root, version):
     console = Console()
     with console.status("Adding build to list of installed versions…"):
-        ihp_sg13g2_family = Family.by_name["ihp_sg13g2"]
+        ihp_sg13g2_family = Family.by_name["ihp-sg13g2"]
 
-        version_directory = Version(version, "ihp_sg13g2").get_dir(pdk_root)
+        version_directory = Version(version, "ihp-sg13g2").get_dir(pdk_root)
         if (
             os.path.exists(version_directory)
             and len(os.listdir(version_directory)) != 0
@@ -94,7 +94,7 @@ def install_ihp(build_directory, pdk_root, version):
             it = 0
             while os.path.exists(backup_path) and len(os.listdir(backup_path)) != 0:
                 it += 1
-                backup_path = Version(f"{version}.bk{it}", "ihp_sg13g2").get_dir(
+                backup_path = Version(f"{version}.bk{it}", "ihp-sg13g2").get_dir(
                     pdk_root
                 )
             console.log(
@@ -132,7 +132,7 @@ def build(
         using_repos = {}
 
     build_directory = os.path.join(
-        get_ciel_dir(pdk_root, "ihp_sg13g2"), "build", version
+        get_ciel_dir(pdk_root, "ihp-sg13g2"), "build", version
     )
     timestamp = datetime.now().strftime("build_ihp-sg13g2-%Y-%m-%d-%H-%M-%S")
     log_dir = os.path.join(build_directory, "logs", timestamp)

--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -21,22 +21,25 @@ from typing import Callable
 
 import click
 
-from .common import VOLARE_RESOLVED_HOME
+from .common import (
+    CIEL_RESOLVED_HOME,
+    get_pdk_family_from_pdk,
+)
 
 opt = partial(click.option, show_default=True)
 
 
 def opt_pdk_root(function: Callable):
     function = opt(
-        "--pdk",
+        "--pdk-family",
         required=False,
-        default=os.getenv("PDK_FAMILY") or "sky130",
-        help="The PDK family to install",
+        default=os.getenv("PDK_FAMILY") or get_pdk_family_from_pdk(os.getenv("PDK")),
+        help="The PDK family to install. If a pdk name is given, ciel attempts to find the corresponding pdk family.",
     )(function)
     function = opt(
         "--pdk-root",
         required=False,
-        default=VOLARE_RESOLVED_HOME,
+        default=CIEL_RESOLVED_HOME,
         help="Path to the PDK root",
     )(function)
     return function

--- a/ciel/common.py
+++ b/ciel/common.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import pathlib
 from datetime import datetime
+from rich.console import Console
 from dataclasses import dataclass
 from typing import Optional, List
 
@@ -43,8 +44,8 @@ def mkdirp(path):
 # -- API Variables
 
 # -- PDK Root Management
-VOLARE_DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".ciel")
-VOLARE_RESOLVED_HOME = os.getenv("PDK_ROOT") or VOLARE_DEFAULT_HOME
+CIEL_DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".ciel")
+CIEL_RESOLVED_HOME = os.getenv("PDK_ROOT") or CIEL_DEFAULT_HOME
 
 
 def _get_current_version(pdk_root: str, pdk: str) -> Optional[str]:
@@ -61,7 +62,7 @@ def _get_current_version(pdk_root: str, pdk: str) -> Optional[str]:
 
 
 def get_ciel_home(pdk_root: Optional[str] = None) -> str:
-    return pdk_root or VOLARE_RESOLVED_HOME
+    return pdk_root or CIEL_RESOLVED_HOME
 
 
 def get_ciel_dir(pdk_root: str, pdk: str) -> str:
@@ -70,6 +71,28 @@ def get_ciel_dir(pdk_root: str, pdk: str) -> str:
 
 def get_versions_dir(pdk_root: str, pdk: str) -> str:
     return os.path.join(get_ciel_dir(pdk_root, pdk), "versions")
+
+
+def get_pdk_family_from_pdk(pdk):
+    if pdk is None:
+        return None
+
+    for pdk_family in Family.by_name.values():
+        if pdk in pdk_family.variants:
+            return pdk_family.name
+
+    return None
+
+
+def print_available_pdk_families():
+    families = [family for family in Family.by_name]
+
+    console = Console()
+    console.print(
+        "Please specify a pdk family using either '--pdk-family' or the 'PDK_FAMILY' environment variable.\n"
+        "Ciel also considers the 'PDK' environment variable and tries to find the corresponding pdk family."
+    )
+    console.print(f"The following pdk families are supported: {', '.join(families)}")
 
 
 @dataclass

--- a/ciel/families.py
+++ b/ciel/families.py
@@ -106,8 +106,8 @@ Family.by_name["gf180mcu"] = Family(
     ],
     repo=opdks_repo,
 )
-Family.by_name["ihp_sg13g2"] = Family(
-    name="ihp_sg13g2",
+Family.by_name["ihp-sg13g2"] = Family(
+    name="ihp-sg13g2",
     variants=["ihp-sg13g2"],
     all_libraries=[
         "sg13g2_io",

--- a/flake.lock
+++ b/flake.lock
@@ -5,15 +5,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1735039316,
-        "narHash": "sha256-T9NFsUbaukW97A0+oQFkgu7/KxAOl3A46Ce8gOGFmZY=",
-        "owner": "efabless",
+        "lastModified": 1743562091,
+        "narHash": "sha256-uoJqa3on+kDu+XxST+TfBFbCkR+md9jXrYg+qHawIxs=",
+        "owner": "fossi-foundation",
         "repo": "nix-eda",
-        "rev": "2bc60735f29c5050cb9740c43f614eac11d2b4ca",
+        "rev": "1e53da779fa9eed6290cd27b8e7f78196028ddfb",
         "type": "github"
       },
       "original": {
-        "owner": "efabless",
+        "owner": "fossi-foundation",
         "repo": "nix-eda",
         "type": "github"
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "1.0.0"
+version = "2.0.0"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = [
     "Mohamed Gaber <me@donn.website>",


### PR DESCRIPTION
* CLI: `--pdk` renamed to `--pdk-family` (with old flag as an alias)
  * Custom click validator ensures that the PDK family is valid (and if not provided, prints a list of supported PDKs)
  * Default value removed: PDK now has to always be explicitly specified and sky130 is no longer given preferential treatment 