### PR TITLE
feat: usability enhancements

### DIFF
--- a/ciel/__main__.py
+++ b/ciel/__main__.py
@@ -17,8 +17,8 @@
 # limitations under the License.
 import sys
 import json
+import shutil
 
-import yaml
 import httpx
 import click
 from rich.console import Console
@@ -332,13 +332,27 @@ def fetch_cmd(
 
 @click.command("ls-pdks")
 def list_pdks_cmd():
+    """Lists PDK families and variants. JSON if not outputting to a tty"""
     result = {}
-    for family in Family.by_name.values():
-        result[family.name] = family.variants
-    print(yaml.dump(result), end="")
+    if sys.stdout.isatty():
+        console = Console()
+        for family in Family.by_name.values():
+            console.print(f"[bold]{family.name}")
+            for variant in family.variants:
+                console.print(
+                    f"- {variant}{" (default)" * (variant == family.default_variant)}"
+                )
+    else:
+        for family in Family.by_name.values():
+            result[family.name] = family.variants
+        print(json.dumps(result), end="")
 
 
-@click.group()
+@click.group(
+    context_settings={
+        "max_content_width": max(shutil.get_terminal_size().columns, 80),
+    }
+)
 @click.version_option(
     __version__,
     message="""Ciel v%(version)s ©2022-2025 Efabless Corporation and Contributors

--- a/ciel/__main__.py
+++ b/ciel/__main__.py
@@ -17,8 +17,9 @@
 # limitations under the License.
 import sys
 import json
-import httpx
 
+import yaml
+import httpx
 import click
 from rich.console import Console
 
@@ -26,16 +27,17 @@ from .__version__ import __version__
 from .common import (
     Version,
     get_ciel_home,
-    resolve_version,
 )
 from .click_common import (
     opt_pdk_root,
+    arg_version,
 )
 from .manage import (
     print_installed_list,
     print_remote_list,
     enable,
     fetch,
+    optimize,
 )
 from .build import (
     build_cmd,
@@ -43,6 +45,7 @@ from .build import (
 )
 from .github import opt_github_token
 from .source import opt_data_source
+from .families import Family
 
 
 @click.command("output")
@@ -83,7 +86,7 @@ def output_cmd(pdk_root, pdk_family):
     prompt="Are you sure? This will delete all non-enabled versions of the PDK from your computer.",
 )
 def prune_cmd(pdk_root, pdk_family):
-    """Removes all PDKs other than, if it exists, the one currently in use."""
+    """Removes all PDKs other than, if it exists, the one currently set as 'enabled' in the PDK root."""
 
     pdk_versions = Version.get_all_installed(pdk_root, pdk_family)
     for version in pdk_versions:
@@ -96,6 +99,48 @@ def prune_cmd(pdk_root, pdk_family):
             print(f"Failed to delete {version}: {e}", file=sys.stderr)
 
 
+@click.command("optimize")
+@opt_pdk_root
+@arg_version
+def optimize_cmd(pdk_root, pdk_family, version):
+    """
+    [Experimental] This command attempts to save space by converting identical
+    files across variants for the specified version to symbolic links.
+
+    This will save space for some items such as GDS and LIB files, but may have
+    some side effects with your own tools. Use at your own discretion.
+
+    Requires a POSIX or POSIX-compatible operating system.
+    """
+
+    recovered = optimize(pdk_root, Version(version, pdk_family))
+
+    console = Console()
+    console.print(f"[bold]{recovered / (1 << 20):.2f}[/bold] MiB recovered.")
+
+
+@click.command("optimize-all")
+@opt_pdk_root
+def optimize_all_cmd(pdk_root, pdk_family):
+    """
+    [Experimental] This command attempts to save space by converting identical
+    files across variants for all versions of a specific PDK family to symbolic
+    links.
+
+    This will save space for some items such as GDS and LIB files, but may have
+    some side effects with your own tools. Use at your own discretion.
+
+    Requires a POSIX or POSIX-compatible operating system.
+    """
+
+    recovered = 0
+    for version in Version.get_all_installed(pdk_root, pdk_family):
+        recovered += optimize(pdk_root, version)
+
+    console = Console()
+    console.print(f"[bold]{recovered / (1 << 20):.2f}[/bold] MiB recovered.")
+
+
 @click.command("rm")
 @opt_pdk_root
 @click.option(
@@ -105,7 +150,7 @@ def prune_cmd(pdk_root, pdk_family):
     expose_value=False,
     prompt="Are you sure? This will delete this version of the PDK from your computer.",
 )
-@click.argument("version", required=False)
+@arg_version
 def rm_cmd(pdk_root, pdk_family, version):
     """Removes the PDK version specified."""
 
@@ -183,7 +228,7 @@ def list_remote_cmd(data_source, pdk_root, pdk_family):
 
 @click.command("path")
 @opt_pdk_root
-@click.argument("version", required=False)
+@arg_version
 def path_cmd(pdk_root, pdk_family, version):
     """
     Prints the path of the ciel PDK root.
@@ -203,47 +248,28 @@ def path_cmd(pdk_root, pdk_family, version):
 @opt_github_token
 @opt_pdk_root
 @click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.option(
     "-l",
     "--include-libraries",
     multiple=True,
     default=None,
-    help="Libraries to include. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
+    help="Libraries to include. You can use  l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
 )
-@click.argument("version", required=False)
+@arg_version
 def enable_cmd(
     data_source,
     pdk_root,
     pdk_family,
-    tool_metadata_file_path,
     version,
     include_libraries,
 ):
     """
     Activates a given installed PDK version.
-
-    Parameters: <version> (Optional)
-
-    If a version is not given, and you run this in the top level directory of
-    tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
-    the appropriate version will be enabled automatically.
     """
 
     if include_libraries == ():
         include_libraries = None
 
     console = Console()
-    try:
-        version = resolve_version(version, tool_metadata_file_path)
-    except Exception as e:
-        console.print(f"Could not determine open_pdks version: {e}")
-        exit(-1)
 
     try:
         enable(
@@ -264,48 +290,29 @@ def enable_cmd(
 @opt_github_token
 @opt_pdk_root
 @click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.option(
     "-l",
     "--include-libraries",
     multiple=True,
     default=None,
     help="Libraries to include. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
 )
-@click.argument("version", required=False)
+@arg_version
 def fetch_cmd(
     data_source,
     pdk_root,
     pdk_family,
-    tool_metadata_file_path,
     version,
     include_libraries,
 ):
     """
     Fetches a PDK to Ciel's store without setting it as the "enabled" version
     in ``PDK_ROOT``.
-
-    Parameters: <version> (Optional)
-
-    If a version is not given, and you run this in the top level directory of
-    tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
-    the appropriate version will be enabled automatically.
     """
 
     if include_libraries == ():
         include_libraries = None
 
     console = Console()
-    try:
-        version = resolve_version(version, tool_metadata_file_path)
-    except Exception as e:
-        console.print(f"Could not determine open_pdks version: {e}")
-        exit(-1)
 
     try:
         version = fetch(
@@ -321,6 +328,14 @@ def fetch_cmd(
     except Exception as e:
         console.print(f"[red]{e}")
         exit(-1)
+
+
+@click.command("ls-pdks")
+def list_pdks_cmd():
+    result = {}
+    for family in Family.by_name.values():
+        result[family.name] = family.variants
+    print(yaml.dump(result), end="")
 
 
 @click.group()
@@ -345,6 +360,8 @@ def cli():
 
 
 cli.add_command(output_cmd)
+cli.add_command(optimize_cmd)
+cli.add_command(optimize_all_cmd)
 cli.add_command(prune_cmd)
 cli.add_command(rm_cmd)
 cli.add_command(build_cmd)
@@ -354,6 +371,7 @@ cli.add_command(list_cmd)
 cli.add_command(list_remote_cmd)
 cli.add_command(enable_cmd)
 cli.add_command(fetch_cmd)
+cli.add_command(list_pdks_cmd)
 
 try:
     import ssl  # noqa: F401

--- a/ciel/build/__init__.py
+++ b/ciel/build/__init__.py
@@ -37,13 +37,13 @@ from ..github import (
 from ..common import (
     Version,
     mkdirp,
-    resolve_version,
     date_to_iso8601,
 )
 from ..click_common import (
     opt_push,
     opt_build,
     opt_pdk_root,
+    arg_version,
 )
 from ..families import Family
 
@@ -85,21 +85,13 @@ def build(
 @opt_github_token
 @opt_pdk_root
 @opt_build
-@click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.argument("version", required=False)
+@arg_version
 def build_cmd(
     include_libraries,
     jobs,
     pdk_root,
     pdk_family,
     clear_build_artifacts,
-    tool_metadata_file_path,
     version,
     use_repo_at,
 ):
@@ -114,13 +106,6 @@ def build_cmd(
     """
     if include_libraries == ():
         include_libraries = None
-
-    console = Console()
-    try:
-        version = resolve_version(version, tool_metadata_file_path)
-    except Exception as e:
-        console.print(f"Could not determine open_pdks version: {e}")
-        exit(-1)
 
     build(
         pdk_root=pdk_root,

--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -71,7 +71,7 @@ def arg_version(f):
 
 class PDKOption(click.Option):
     def get_usage_pieces(self, ctx):
-        return ["<--pdk-family PDK_FAMILY>"]
+        return [f"<--pdk-family {'|'.join(Family.by_name)}>"]
 
     def process_value(self, ctx: click.Context, value):
         value = self.type_cast_value(ctx, value)

--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -23,34 +23,83 @@ import click
 from .common import (
     CIEL_RESOLVED_HOME,
     resolve_pdk_family,
+    resolve_version,
 )
 from .families import Family
 
 opt = partial(click.option, show_default=True)
 
 
-def pdk_cb(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: Optional[str],
-):
-    try:
-        resolved = resolve_pdk_family(value)
-    except ValueError as e:
-        raise click.BadParameter(str(e), ctx, param)
-    if resolved is None:
-        raise click.BadParameter(
-            f"A PDK family or variant must be specified. The following families are supported: {', '.join(Family.by_name)}"
-        )
-    return resolved
+class VersionArgument(click.Argument):
+    def make_metavar(self):
+        return "<VERSION>"
+
+    def set_tool_metadata_file_path(
+        self,
+        ctx: click.Context,
+        param: click.Parameter,
+        value: Optional[str],
+    ):
+        self.tool_metadata_file_path = value
+
+    def process_value(self, ctx, value):
+        try:
+            tool_metadata_file_path = None
+            if "tool_metadata_file_path" in ctx.params:
+                tool_metadata_file_path = ctx.params["tool_metadata_file_path"]
+                del ctx.params["tool_metadata_file_path"]
+            resolved = resolve_version(value, tool_metadata_file_path)
+        except FileNotFoundError:
+            resolved = None
+        return super().process_value(ctx, resolved)
+
+
+def arg_version(f):
+    version_param = VersionArgument(["version"], required=True)
+    f = click.option(
+        "-f",
+        "--metadata-file",
+        "tool_metadata_file_path",
+        default=None,
+        expose_value=False,
+        callback=version_param.set_tool_metadata_file_path,
+        help="Explicitly define a tool metadata file instead of searching for a metadata file",
+    )(f)
+    f.__click_params__.append(version_param)
+    return f
+
+
+class PDKOption(click.Option):
+    def get_usage_pieces(self, ctx):
+        return ["<--pdk-family PDK_FAMILY>"]
+
+    def process_value(self, ctx: click.Context, value):
+        value = self.type_cast_value(ctx, value)
+
+        if self.required and self.value_is_missing(value):
+            raise click.MissingParameter(
+                message=f"A PDK family or variant must be specified. The following families are supported: {', '.join(Family.by_name)}",
+                ctx=ctx,
+                param=self,
+            )
+
+        if self.callback is not None:
+            value = self.callback(ctx, self, value)
+
+        try:
+            resolved = resolve_pdk_family(value)
+        except ValueError as e:
+            raise click.BadParameter(str(e), ctx=ctx, param=self)
+
+        return resolved
 
 
 def opt_pdk_root(function: Callable):
     function = opt(
         "--pdk-family",
         "--pdk",
-        required=False,  # Requirement handled by callback
-        callback=pdk_cb,
+        cls=PDKOption,
+        required=True,
         help="A valid PDK family or variant (the latter of which is resolved to a family).",
     )(function)
     function = opt(

--- a/ciel/common.py
+++ b/ciel/common.py
@@ -204,7 +204,7 @@ class Version(object):
 
 def resolve_version(
     version: Optional[str],
-    tool_metadata_file_path: Optional[str],
+    tool_metadata_file_path: Optional[str] = None,
 ) -> str:
     """
     Takes an optional version and tool_metadata_file_path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "2.0.4"
+version = "2.1.0"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = ["Mohamed Gaber <me@donn.website>", "Efabless Corporation"]
 readme = "Readme.md"


### PR DESCRIPTION
- new commands `optimize`, `optimize-all` that attempt to deduplicate files across PDK variants using their hash for either a single version or a single family (POSIX only)
- new command `ls-pdks` to print out all pdk families and variants to the terminal (in JSON for non-ttys just like `ls`, `ls-remote`)
- updated pdk family and version parameters to use correct UNIX conventions `<>` (non-optional) in help strings
- `--help` now no longer truncated on wider terminals, uses `max(80, USER_TERMINAL_COLUMNS)` 
- a number of non-user-facing tweaks to the CLI

---

Resolves #107, resolves #106, partially resolves #98