### PR TITLE
hotfix: handle `Sentinel.UNSET` in click ≥ 8.3.0

### DIFF
--- a/ciel/click_common.py
+++ b/ciel/click_common.py
@@ -44,6 +44,9 @@ class VersionArgument(click.Argument):
 
     def process_value(self, ctx, value):
         try:
+            # handle sentinels in click ≥ 8.3.0
+            if hasattr(value, "name") and value.name == "UNSET":
+                value = None
             tool_metadata_file_path = None
             if "tool_metadata_file_path" in ctx.params:
                 tool_metadata_file_path = ctx.params["tool_metadata_file_path"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "2.3.0"
+version = "2.3.1"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = ["Mohamed Gaber <me@donn.website>", "Efabless Corporation"]
 readme = "Readme.md"


### PR DESCRIPTION
Should resolve https://github.com/The-OpenROAD-Project/OpenLane/issues/2195

I've elected to just add a duck-typing handler to detect the sentinel. Surprisingly, this did not piss off mypy.

---

I suppose every minor release of Click I should just expect a lil quirky surprise like that huh https://github.com/librelane/librelane/commit/529b71e09177b402663b00aa3b3dd70a4a66930b