### PR TITLE
Change return type to GitHubSession in downloads method

### DIFF
--- a/ciel/source.py
+++ b/ciel/source.py
@@ -46,7 +46,7 @@ class DataSource(object):
 
     def get_downloads_for_version(
         self, version: Version
-    ) -> Tuple[httpx.Client, List[Asset]]:
+    ) -> Tuple[GitHubsession, List[Asset]]:
         raise NotImplementedError()
 
 
@@ -110,7 +110,7 @@ class GitHubReleasesDataSource(DataSource):
 
     def get_downloads_for_version(
         self, version: Version
-    ) -> Tuple[httpx.Client, List[Asset]]:
+    ) -> Tuple[GitHubSession, List[Asset]]:
         release = self.session.api(
             self.repo,
             f"/releases/tags/{version.pdk}-{version.name}",
@@ -169,7 +169,7 @@ class StaticWebDataSource(DataSource):
 
     def get_downloads_for_version(
         self, version: Version
-    ) -> Tuple[httpx.Client, List[Asset]]:
+    ) -> Tuple[GitHubSession, List[Asset]]:
         req = self.session.request(
             "GET", self.base_url + f"/{version.pdk}/{version.name}/manifest.json"
         )


### PR DESCRIPTION
The method was documented to return an httpx.Client, but actually returns a GitHubSession.
The type hints are updated to reflect the real return value, improving type correctness and preventing confusion for contributors and static type checkers.