### PR TITLE
fix: naming of 3.3V SRAM library

### DIFF
--- a/ciel/build/gf180mcu.py
+++ b/ciel/build/gf180mcu.py
@@ -104,7 +104,7 @@ LIB_FLAG_MAP = {
     "gf180mcu_osu_sc_gp9t3v3": "--enable-osu-sc-gf180mcu",
     "gf180mcu_as_sc_mcu7t3v3": "--enable-avalon-sc-gf180mcu",
     "gf180mcu_ocd_io": "--enable-ocd-io-gf180mcu",
-    "gf180mcu_ocd_sram": "--enable-ocd-sram-gf180mcu",
+    "gf180mcu_ocd_ip_sram": "--enable-ocd-sram-gf180mcu",
     "gf180mcu_ocd_alpha_small": "--enable-alpha-gf180mcu",
     "gf180mcu_ocd_alpha_large": "--enable-alpha-gf180mcu",
     "gf180mcu_ocd_alpha_misc": "--enable-alpha-gf180mcu",

--- a/ciel/families.py
+++ b/ciel/families.py
@@ -98,7 +98,7 @@ Family.by_name["gf180mcu"] = Family(
         "gf180mcu_osu_sc_gp9t3v3",
         "gf180mcu_as_sc_mcu7t3v3",
         "gf180mcu_ocd_io",
-        "gf180mcu_ocd_sram",
+        "gf180mcu_ocd_ip_sram",
         "gf180mcu_ocd_alpha_small",
         "gf180mcu_ocd_alpha_large",
         "gf180mcu_ocd_alpha_misc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "2.4.0"
+version = "2.4.1"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = ["Mohamed Gaber <me@donn.website>", "Efabless Corporation"]
 readme = "Readme.md"


### PR DESCRIPTION
The name was missing the `ip_` part, which lead to the library not being included in ciel. This PR fixes that.