### PR TITLE
documentation: fixing link still pointing to efabless git repository

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ ciel --version
 ```
 
 # About the builds
-In its current inception, ciel supports builds of **sky130** and **gf180mcu** PDKs using [Open_PDKs](https://github.com/efabless/open_pdks), including the following libraries:
+In its current inception, ciel supports builds of **sky130** and **gf180mcu** PDKs using [Open-PDKs](https://github.com/rtimothyedwards/open_pdks), including the following libraries:
 
 |sky130|gf180mcu|ihp-sg13g2|
 |-|-|-|


### PR DESCRIPTION
Unless the intention was to point to the old `efabless` repository, then the link should point to the currently active and in use repository. Otherwise it can get be hard to find the code for the newest versions while looking at an unmaintained repository.