### PR TITLE
feat: rename default open-pdks branch to main

### DIFF
--- a/ciel/build/gf180mcu.py
+++ b/ciel/build/gf180mcu.py
@@ -54,7 +54,7 @@ def get_open_pdks(
                         gmc,
                         opdks_repo.link,
                         version,
-                        default_branch="master",
+                        default_branch="main",
                     )
                     open_pdks_repo = open_pdks_future.result()
                     repo_path = open_pdks_repo.path

--- a/ciel/build/sky130.py
+++ b/ciel/build/sky130.py
@@ -55,7 +55,7 @@ def get_open_pdks(
                         gmc,
                         opdks_repo.link,
                         version,
-                        default_branch="master",
+                        default_branch="main",
                     )
                     open_pdks_repo = open_pdks_future.result()
                     repo_path = open_pdks_repo.path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciel"
-version = "2.5.1"
+version = "2.6.0"
 description = "An PDK builder/version manager for PDKs in the open_pdks format"
 authors = ["Mohamed Gaber <me@donn.website>", "Efabless Corporation"]
 readme = "Readme.md"


### PR DESCRIPTION
Since [Open PDKs](https://github.com/fossi-foundation/open-pdks) has been moved to the FOSSi Foundation, I took the liberty to rename the default branch to `main`.

This PR updates Ciel accordingly.