### PR TITLE
Introduce ciel-specific exception classes

### DIFF
--- a/ciel/__init__.py
+++ b/ciel/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .exceptions import CielRuntimeError, CielValueError
 from .manage import (
     VersionNotFound,
     enable,
@@ -27,3 +28,18 @@ from .github import (
 )
 from .build import build
 from .__version__ import __version__
+
+__all__ = [
+    "CielRuntimeError",
+    "CielValueError",
+    "VersionNotFound",
+    "enable",
+    "get",
+    "fetch",
+    "get_ciel_home",
+    "Version",
+    "Family",
+    "GitHubSession",
+    "build",
+    "__version__",
+]

--- a/ciel/build/__init__.py
+++ b/ciel/build/__init__.py
@@ -46,6 +46,7 @@ from ..click_common import (
     arg_version,
 )
 from ..families import Family
+from ..exceptions import CielValueError
 
 
 def build(
@@ -65,7 +66,7 @@ def build(
             use_repos[name] = os.path.abspath(path)
 
     if pdk_family not in Family.by_name:
-        raise Exception(f"Unsupported PDK family '{pdk_family}'.")
+        raise CielValueError(f"Unsupported PDK family '{pdk_family}'.")
 
     kwargs = {
         "pdk_root": pdk_root,

--- a/ciel/common.py
+++ b/ciel/common.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 from .families import Family
+from .exceptions import CielValueError
 
 # -- Assorted Helper Functions
 ISO8601_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -111,7 +112,7 @@ def resolve_pdk_family(selector: Optional[str]):
         if selector in pdk_family.variants:
             return pdk_family.name
 
-    raise ValueError(f"'{selector}' is not a valid PDK family or variant.")
+    raise CielValueError(f"'{selector}' is not a valid PDK family or variant.")
 
 
 def resolve_pdk_variant(selector: Optional[str]):
@@ -137,7 +138,7 @@ def resolve_pdk_variant(selector: Optional[str]):
         if selector in pdk_family.variants:
             return selector
 
-    raise ValueError(f"'{selector}' is not a valid PDK family or variant.")
+    raise CielValueError(f"'{selector}' is not a valid PDK family or variant.")
 
 
 @dataclass
@@ -181,7 +182,7 @@ class Version(object):
 
     def uninstall(self, pdk_root: str):
         if not self.is_installed(pdk_root):
-            raise ValueError(
+            raise CielValueError(
                 f"Version {self.name} of the {self.pdk} PDK is not installed."
             )
 
@@ -253,7 +254,7 @@ def resolve_version(
     open_pdks_list = [tool for tool in tool_metadata if tool["name"] == "open_pdks"]
 
     if len(open_pdks_list) < 1:
-        raise ValueError("No entry for open_pdks found in tool_metadata.yml")
+        raise CielValueError("No entry for open_pdks found in tool_metadata.yml")
 
     version = open_pdks_list[0]["commit"]
 

--- a/ciel/exceptions.py
+++ b/ciel/exceptions.py
@@ -1,0 +1,21 @@
+# Copyright 2025 The American University in Cairo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class CielValueError(ValueError):
+    """Raised when ciel receives invalid user input or configuration."""
+
+
+class CielRuntimeError(RuntimeError):
+    """Raised when ciel encounters an unexpected runtime failure."""

--- a/ciel/families.py
+++ b/ciel/families.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Dict, Optional, Set, ClassVar
 
 from .github import RepoInfo, opdks_repo, ihp_repo
+from .exceptions import CielValueError
 
 
 @dataclass
@@ -51,7 +52,7 @@ class Family(object):
             elif element in self.all_libraries:
                 final_set.add(element)
             else:
-                raise ValueError(f"Unknown library {element} for PDK {self.name}")
+                raise CielValueError(f"Unknown library {element} for PDK {self.name}")
         return final_set
 
 

--- a/ciel/github.py
+++ b/ciel/github.py
@@ -26,6 +26,7 @@ from typing import Any, ClassVar, Optional, Callable
 import httpx
 import ssl
 from .__version__ import __version__
+from .exceptions import CielValueError
 
 
 @dataclass
@@ -144,7 +145,7 @@ class GitHubSession(httpx.Client):
         try:
             return req.json()
         except ValueError as e:
-            raise ValueError(f"Request {req.url} returned invalid JSON: {e}") from None
+            raise CielValueError(f"Request {req.url} returned invalid JSON: {e}") from None
 
     @classmethod
     def get_user_agent(Self) -> str:

--- a/ciel/manage.py
+++ b/ciel/manage.py
@@ -40,9 +40,10 @@ from .common import (
 from .build import build, push
 from .families import Family
 from .source import DataSource
+from .exceptions import CielRuntimeError, CielValueError
 
 
-class VersionNotFound(Exception):
+class VersionNotFound(CielValueError):
     pass
 
 
@@ -140,7 +141,7 @@ def fetch(
 
     pdk_family = Family.by_name.get(pdk)
     if pdk_family is None:
-        raise ValueError(f"Unsupported PDK family '{pdk}'.")
+        raise CielValueError(f"Unsupported PDK family '{pdk}'.")
 
     library_set = pdk_family.resolve_libraries(include_libraries)
 
@@ -154,7 +155,7 @@ def fetch(
 
     for library in library_set:
         if library not in pdk_family.all_libraries:
-            raise RuntimeError(f"Unknown library {library}.")
+            raise CielRuntimeError(f"Unknown library {library}.")
         found = False
         for variant in variants:
             lib_path = os.path.join(version_directory, variant, "libs.ref", library)
@@ -226,7 +227,7 @@ def fetch(
         except httpx.HTTPStatusError as e:
             if e.response is not None and e.response.status_code == 404:
                 if not build_if_not_found:
-                    raise RuntimeError(f"Version {version} not found remotely.")
+                    raise CielRuntimeError(f"Version {version} not found remotely.")
                 console.print(
                     f"Version {version} not found remotely, attempting to build…"
                 )
@@ -249,11 +250,11 @@ def fetch(
                     )
             else:
                 if e.response is not None:
-                    raise RuntimeError(
+                    raise CielRuntimeError(
                         f"Failed to obtain {version} remotely: {e.response}."
                     )
                 else:
-                    raise RuntimeError(f"Failed to request {version} from server: {e}.")
+                    raise CielRuntimeError(f"Failed to request {version} from server: {e}.")
         except KeyboardInterrupt as e:
             console.print("Interrupted.")
             for path in affected_paths:
@@ -305,7 +306,7 @@ def enable(
 
     pdk_family = Family.by_name.get(pdk)
     if pdk_family is None:
-        raise ValueError(f"Unsupported PDK family '{pdk}'.")
+        raise CielValueError(f"Unsupported PDK family '{pdk}'.")
 
     variants = pdk_family.variants
     version_paths = [os.path.join(version_directory, variant) for variant in variants]

--- a/ciel/source.py
+++ b/ciel/source.py
@@ -25,6 +25,7 @@ import httpx
 
 from .github import GitHubSession, RepoInfo
 from .common import Version, date_from_iso8601
+from .exceptions import CielValueError
 
 
 @dataclass
@@ -103,7 +104,7 @@ class GitHubReleasesDataSource(DataSource):
 
         versions.sort(reverse=True)
         if len(versions) == 0:
-            raise ValueError(
+            raise CielValueError(
                 f"No versions found for '{pdk}' on github.com/{self.repo.id}"
             )
         return versions
@@ -142,7 +143,7 @@ class StaticWebDataSource(DataSource):
             req.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(
+                raise CielValueError(
                     f"No versions found for '{pdk}' at '{self.base_url}'"
                 ) from None
             else:
@@ -150,7 +151,7 @@ class StaticWebDataSource(DataSource):
         try:
             manifest = req.json()
         except ValueError as e:
-            raise ValueError(f"Request {req.url} returned invalid JSON: {e}") from None
+            raise CielValueError(f"Request {req.url} returned invalid JSON: {e}") from None
 
         versions = []
         for version in manifest["versions"]:
@@ -164,7 +165,7 @@ class StaticWebDataSource(DataSource):
 
         versions.sort(reverse=True)
         if len(versions) == 0:
-            raise ValueError(f"No versions found for '{pdk}' on '{self.base_url}'")
+            raise CielValueError(f"No versions found for '{pdk}' on '{self.base_url}'")
         return versions
 
     def get_downloads_for_version(
@@ -177,7 +178,7 @@ class StaticWebDataSource(DataSource):
             req.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(
+                raise CielValueError(
                     f"Manifest for '{version.pdk}/{version.name}' at '{self.base_url}'"
                 ) from None
             else:
@@ -185,7 +186,7 @@ class StaticWebDataSource(DataSource):
         try:
             manifest = req.json()
         except ValueError as e:
-            raise ValueError(f"Request {req.url} returned invalid JSON: {e}") from None
+            raise CielValueError(f"Request {req.url} returned invalid JSON: {e}") from None
 
         assets = []
         for asset in manifest["assets"]:


### PR DESCRIPTION
## Summary
- Add `CielValueError` and `CielRuntimeError` inheriting from `ValueError` and `RuntimeError`.
- Raise these classes from ciel's own code instead of bare stdlib exceptions.
- Make `VersionNotFound` inherit from `CielValueError`.

Fixes #131